### PR TITLE
Add GameplayQA (ACL 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@
 
 ## benchmark
 
+- [2026/03] **GameplayQA: A Benchmarking Framework for Decision-Dense POV-Synced Multi-Video Understanding of 3D Virtual Agents** *ACL 2026* [[paper](https://arxiv.org/abs/2603.24329)][[code](https://github.com/HATS-ICT/GameplayQA)] `#benchmark` `#multi-agent` `#vlm`
 - [2026/01] **NitroGen: An Open Foundation Model for Generalist Gaming Agents** *arXiv* [[paper](https://arxiv.org/abs/2601.02427)] `#benchmark` `#training`
 - [2025/10] **Think Globally, Group Locally: Evaluating LLMs Using Multi-Lingual Word Grouping Games** *EMNLP 2025* [[paper](https://arxiv.org/abs/2510.14030)] `#benchmark`
 - [2025/06] **Orak: A Foundational Benchmark for Training and Evaluating LLM Agents on Diverse Video Games** *arXiv* [[paper](https://arxiv.org/pdf/2506.03610)][[code](https://github.com/krafton-ai/Orak)] `#benchmark` `#training`


### PR DESCRIPTION

Hey there, nice list — thanks for maintaining it. Could I add GameplayQA to the #benchmark section? GameplayQA is a recent multi-video understanding benchmark (ACL 2026). It's a game-playing/evaluation benchmark that probes MLLMs as the perceptual system for agents in 3D/esports environments, alongside Orak and BALROG.

Paper: https://arxiv.org/abs/2603.24329 | Project: https://hats-ict.github.io/gameplayqa/

Thanks!